### PR TITLE
Fix redundant redeem on zero-amount emergency withdraw

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,20 @@
+{
+  "lib/forge-std": {
+    "branch": {
+      "name": "master",
+      "rev": "fc560fa34fa12a335a50c35d92e55a6628ca467c"
+    }
+  },
+  "lib/openzeppelin-contracts": {
+    "branch": {
+      "name": "v4.9.5",
+      "rev": "bd325d56b4c62c9c5c1aff048c37c6bb18ac0290"
+    }
+  },
+  "lib/tokenized-strategy": {
+    "rev": "82806289f967590c4efbf6bc3d237e4e7f0a0966"
+  },
+  "lib/tokenized-strategy-periphery": {
+    "rev": "fc802464cb8ec6dacea20d8309dc7f82a2739710"
+  }
+}

--- a/src/BaseLenderBorrower.sol
+++ b/src/BaseLenderBorrower.sol
@@ -663,7 +663,7 @@ abstract contract BaseLenderBorrower is BaseHealthCheck {
             lenderVault.previewWithdraw(amount),
             lenderVault.balanceOf(address(this))
         );
-        lenderVault.redeem(shares, address(this), address(this));
+        if (shares > 0) lenderVault.redeem(shares, address(this), address(this));
     }
 
     // ----------------- INTERNAL VIEW FUNCTIONS ----------------- \\

--- a/src/BaseLenderBorrower.sol
+++ b/src/BaseLenderBorrower.sol
@@ -663,7 +663,7 @@ abstract contract BaseLenderBorrower is BaseHealthCheck {
             lenderVault.previewWithdraw(amount),
             lenderVault.balanceOf(address(this))
         );
-        if (shares > 0) lenderVault.redeem(shares, address(this), address(this));
+        lenderVault.redeem(shares, address(this), address(this));
     }
 
     // ----------------- INTERNAL VIEW FUNCTIONS ----------------- \\
@@ -978,9 +978,8 @@ abstract contract BaseLenderBorrower is BaseHealthCheck {
      * @param _amount The amount of asset to attempt to free.
      */
     function _emergencyWithdraw(uint256 _amount) internal virtual override {
-        if (_amount > 0) {
-            _withdrawBorrowToken(Math.min(_amount, _lenderMaxWithdraw()));
-        }
+        _amount = Math.min(_amount, _lenderMaxWithdraw());
+        if (_amount > 0) _withdrawBorrowToken(_amount);
 
         // Repay everything we can.
         _repayTokenDebt();


### PR DESCRIPTION
Make sure `_lenderMaxWithdraw()` does not return `0` before calling `_withdrawBorrowToken()` in `_emergencyWithdraw()`